### PR TITLE
Add support for Release Drafter configs and Markdown output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y jq && rm -rf /var
 COPY generate-jenkins-changelog.rb /jenkins-changelog-generator/bin/generate-jenkins-changelog
 COPY lts-backports-changelog.rb /jenkins-changelog-generator/bin/lts-backports-changelog
 COPY docker-runner.rb /jenkins-changelog-generator/bin/jenkins-changelog-generator
+COPY release-drafter.yml /jenkins-changelog-generator/config/release-drafter.yml
 RUN chmod +x /jenkins-changelog-generator/bin/*
 
 VOLUME /github/workspace
@@ -13,5 +14,7 @@ WORKDIR /github/workspace
 
 # Forces creation
 ENV CHANGELOG_YAML_PATH=/github/workspace/changelog.yaml
+ENV CHANGELOG_MD_PATH=/github/workspace/changelog.md
+ENV CONFIG_PATH=/jenkins-changelog-generator/config/release-drafter.yml
 
 ENTRYPOINT ["/jenkins-changelog-generator/bin/jenkins-changelog-generator"]

--- a/release-drafter.yml
+++ b/release-drafter.yml
@@ -1,0 +1,82 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+# The configuration is extended by the id field for categories
+name-template: $NEXT_MINOR_VERSION
+tag-template: $NEXT_MINOR_VERSION
+# Uses a more common 2-digit versioning in Jenkins plugins. Can be replaced by semver: $MAJOR.$MINOR.$PATCH
+version-template: $MAJOR.$MINOR
+
+# Emoji reference: https://gitmoji.carloscuesta.me/
+categories:
+  - title: ":boom: Breaking changes"
+    labels: 
+      - breaking
+  - title: 🚨 Removed
+    label: removed
+  - title: ":tada: Major features and improvements"
+    labels:
+      - major-enhancement
+      - major-rfe
+  - title: 🐛 Major bug fixes
+    labels:
+      - major-bug
+  - title: ⚠️ Deprecated
+    label: deprecated
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+      - rfe
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+      - regression
+  - title: ":construction_worker: Changes for plugin developers"
+    labels:
+      - developer 
+  # Default label used by Dependabot
+  - title: 📦 Dependency updates
+    label: dependencies
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 👻 Maintenance
+    labels: 
+      - chore
+      - internal
+  - title: 🚦 Tests
+    labels: 
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES
+
+replacers:
+  - search: '/\[*JENKINS-(\d+)\]*\s*-*\s*/g'
+    replace: '[JENKINS-$1](https://issues.jenkins-ci.org/browse/JENKINS-$1) - '
+  - search: '/\[*INFRA-(\d+)\]*\s*-*\s*/g'
+    replace: '[INFRA-$1](https://issues.jenkins-ci.org/browse/INFRA-$1) - '
+  - search: '/\[*WEBSITE-(\d+)\]*\s*-*\s*/g'
+    replace: '[WEBSITE-$1](https://issues.jenkins-ci.org/browse/WEBSITE-$1) - '
+  - search: '/\[*HOSTING-(\d+)\]*\s*-*\s*/g'
+    replace: '[HOSTING-$1](https://issues.jenkins-ci.org/browse/HOSTING-$1) - '  
+  # TODO(oleg_nenashev): Find a better way to reference issues
+  - search: '/\[*SECURITY-(\d+)\]*\s*-*\s*/g'
+    replace: '[SECURITY-$1](https://jenkins.io/security/advisories/) - '
+  - search: '/\[*JEP-(\d+)\]*\s*-*\s*/g'
+    replace: '[JEP-$1](https://github.com/jenkinsci/jep/tree/master/jep/$1) - '
+  - search: '/CVE-(\d{4})-(\d+)/g'
+    replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
+  - search: 'JFR'
+    replace: 'Jenkinsfile Runner'
+  - search: 'CWP'
+    replace: 'Custom WAR Packager'
+  - search: '@dependabot-preview'
+    replace: '@dependabot'


### PR DESCRIPTION
The change implements the Release Drafter configuration format support and markdown output, with many limitations. But the  logic works for our configuration file in https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.yml

Limitations:

* Changelog and Entry format is hardcoded (for now)
* replacers: only plaintext and `/something/g` regexps are supported, no full-line fetching

Sample Markdown output for Jenkins 2.221:

```
**Disclaimer**: This is an automatically generated changelog draft for Jenkins weekly releases.
See https://jenkins.io/changelog/ for the official changelogs.
For `changelog.yaml` drafts see GitHub action artifacts attached to release commits.

## 🚀 New features and improvements

* Update script-security to 1.70 (#4490) @daniel-beck
* Do not show disabled permissions in permission errors (#4482) @daniel-beck

## 🐛 Bug Fixes

* [JENKINS-61071](https://issues.jenkins-ci.org/browse/JENKINS-61071) - Ensure that initialization tasks run as SYSTEM (#4491) @jglick @timja

## :construction_worker: Changes for plugin developers

* Add extensible background build discarders (#4368) @daniel-beck
* update AdministrativeMonitor javadoc to reference alert-danger not alert-error (#4493) @jtnord @MarkEWaite
* Add preauth filtering overload of getAllItems(), getItems() and allItems() (#4469) @res0nance

## 👻 Maintenance

* [JENKINS-60866](https://issues.jenkins-ci.org/browse/JENKINS-60866) - Un-inline JavaScript / CSS from HudsonPrivateSecurity… (#4455) @Wadeck
* Add findsecbugs plugin to spotbugs. (#4381) @jeffret-b
* Changed exception presented when AtomicFileWriter fails to write to file (#3989) @olivergondza

All contributors: @jglick @timja @Wadeck @jeffret-b @daniel-beck @testfixer @jtnord @MarkEWaite @olivergondza @res0nance @contextshuffling

```