### PR TITLE
Do not consider regressions as a major bug by default

### DIFF
--- a/generate-jenkins-changelog.rb
+++ b/generate-jenkins-changelog.rb
@@ -77,10 +77,10 @@ diff.each_line do |line|
 			entry['type'] = 'rfe' if labels.include?("developer")
 			entry['type'] = 'rfe' if labels.include?("internal")
 			entry['type'] = 'bug' if labels.include?("bug")
+			entry['type'] = 'bug' if labels.include?("regression-fix")
 			entry['type'] = 'rfe' if labels.include?("rfe")
 			entry['type'] = 'major bug' if labels.include?("major-bug")
 			entry['type'] = 'major rfe' if labels.include?("major-rfe")
-			entry['type'] = 'major bug' if labels.include?("regression-fix")
 
 			# Fetch categories by labels
 			config['categories'].each do | category |


### PR DESCRIPTION
Follow-up to https://github.com/jenkins-infra/jenkins.io/pull/4280#discussion_r618125568 and similar discussions. Not all regressions qualify to be major defects in the changelog. Let's stop categorizing them as major defects unless `major-bug` label is set explicitly 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
