### PR TITLE
Include `removed` label in the changelog

### DIFF
--- a/changelog-config.yml
+++ b/changelog-config.yml
@@ -24,6 +24,7 @@ categories:
       - enhancement
       - feature
       - rfe
+      - removed
   - title: regression
     labels:
       - regression-fix

--- a/generate-jenkins-changelog.rb
+++ b/generate-jenkins-changelog.rb
@@ -79,6 +79,7 @@ diff.each_line do |line|
 			entry['type'] = 'bug' if labels.include?("bug")
 			entry['type'] = 'bug' if labels.include?("regression-fix")
 			entry['type'] = 'rfe' if labels.include?("rfe")
+			entry['type'] = 'rfe' if labels.include?("removed")
 			entry['type'] = 'major bug' if labels.include?("major-bug")
 			entry['type'] = 'major rfe' if labels.include?("major-rfe")
 


### PR DESCRIPTION
## Include `removed` label in changelog

Pull requests to Jenkins core that were labeled with `removed` were not included in the automated weekly changelogs for Jenkins 2.339 and earlier.  Let's include them in the changelog.

Original issue was reported at https://github.com/jenkinsci/jenkins/pull/6111#issuecomment-1070465653

https://github.com/jenkins-infra/jenkins.io/pull/4960#issuecomment-1070519721 raises the issue in response to the question asking why the JNDI removal was not included in the [2.332.1 upgrade guide](https://www.jenkins.io/doc/upgrade-guide/2.332/#upgrading-to-jenkins-lts-2-332-1).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
