### PR TITLE
Allow git commands in directory not owned by current user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ ENV CHANGELOG_YAML_PATH=/github/workspace/changelog.yaml
 ENV CHANGELOG_MD_PATH=/github/workspace/changelog.md
 ENV CONFIG_PATH=/jenkins-changelog-generator/config/release-drafter.yml
 
+# Allow clone and other git operations in a directory not owned by the current user
+RUN git config --global --add safe.directory /github/workspace
+
 ENTRYPOINT ["/jenkins-changelog-generator/bin/jenkins-changelog-generator"]

--- a/docker-runner.rb
+++ b/docker-runner.rb
@@ -2,6 +2,7 @@
 
 if Dir.glob("*").empty?
     puts "Running in empty directory, '/src/jenkins' is not passed as volume. Will clone the repository"
+    system("git config --global --add safe.directory %s" % [Dir.getwd])
     system("git clone https://github.com/jenkinsci/jenkins.git .")
     if $?.exitstatus  != 0
         puts "ERROR: Clone failed"

--- a/generate-weekly-changelog.sh
+++ b/generate-weekly-changelog.sh
@@ -12,6 +12,7 @@ CHANGELOG_GENERATOR_REPO=jenkinsci/core-changelog-generator
 if [ ! -d "../jenkins.io" ]
 then
     cd ../
+    git config --global --add safe.directory $(pwd)
     gh repo clone ${JENKINS_IO_REPO}
 
     cd jenkins
@@ -20,6 +21,7 @@ fi
 if [ ! -d "../core-changelog-generator" ]
 then
     cd ../
+    git config --global --add safe.directory $(pwd)
     gh repo clone ${CHANGELOG_GENERATOR_REPO}
 
     cd jenkins


### PR DESCRIPTION
##     Allow git commands in directory not owned by current user

Command line git fixed a security issue by blocking clone into a directory that is not owned by the current user.  This allows the user in the Dockerfile to perform operations as needed on the repository.

Ignore the security fix with a global configuration because this repository trusts the contents of the repositories that it clones.

### Testing done

Built the container image and ran it from my local Jenkins core repository with the commands:

```bash
$ cd ~/hub/core/core-changelog-generator
$ docker build -t jenkins/core-changelog-generator .
$ cd ~/hub/core/jenkins
$ docker run -e GITHUB_AUTH=${GITHUB_AUTH} -e LANG=C.UTF-8 -v $(pwd):/github/workspace --rm jenkins/core-changelog-generator
```

Confirmed that the resulting changelog.yml file contained the expected changes since the most recent release of Jenkins core.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
